### PR TITLE
Added date-based filename patterns

### DIFF
--- a/load.py
+++ b/load.py
@@ -186,7 +186,10 @@ def plugin_prefs(parent, cmdr, is_beta):
         "SYSTEM_(BODY)_CMDR_NNNNN.png",
         "SYSTEM_(BODY)_CMDR_DATE.png",
         "SYSTEM BODY (CMDR) NNNNN.png",
-        "SYSTEM BODY (CMDR) DATE.png"
+        "SYSTEM BODY (CMDR) DATE.png",
+        "DATE_SYSTEM_BODY.png",
+        "DATE_SYSTEM_CMDR.png",
+        "DATE_SYSTEM_BODY_CMDR.png"
     ]
 
     this.maskVar = tk.StringVar(frame)


### PR DESCRIPTION
Added patterns for screenshot filenames starting with DATE.
I usually sort my screenshots based on DATE, making it compatible with the screenshot conversion lists of EDDiscovery.
DATE_SYSTEM_BODY.png is my favorite and default setting here ;-)