### PR TITLE
Swallow status.json load errors

### DIFF
--- a/load.py
+++ b/load.py
@@ -381,12 +381,13 @@ def thumbnail(img, size, xy):
 def getGuiFocus():
     status = "{}\status.json".format(config.default_journal_dir)
     debug(status)
-    with open(status) as json_file:
-        data = json.load(json_file)
     try:
+      with open(status) as json_file:
+        data = json.load(json_file)
         debug(data["GuiFocus"])
         return data["GuiFocus"]
-    except:
+    except Exception as e:
+        debug("Unable to get GuiFocus. {}".format(e))
         return
 
 


### PR DESCRIPTION
Move the `try` up so it swallows `json.load()` errors as well. Fixes #45 

It's OK for the return to be blank because `focus` is only compared to constant numbers and not used where it might be bad to be None 

This should allow screenshots to continue to be processed, but possibly without cropping, when `getGuiFocus()` fails.

I haven't actually tested this as I am nowhere near that body anymore. Please review!