### PR TITLE
strip filenames of certain characters, but keep valid ones found

### DIFF
--- a/load.py
+++ b/load.py
@@ -322,6 +322,9 @@ def getFilename(source, system, body, cmdr):
     mask = getFileMask(source, system, body, cmdr)
     debug("Output Mask: " + mask)
 
+    keepcharacters = (' ','.','_','+','-','(',')',',','#','\'')
+    mask = "".join(c for c in mask if c.isalnum() or c in keepcharacters).rstrip()
+
     files = glob.glob(dir + '/' + mask)
 
     # This is not very elegant. Is there a better way?

--- a/load.py
+++ b/load.py
@@ -322,7 +322,7 @@ def getFilename(source, system, body, cmdr):
     mask = getFileMask(source, system, body, cmdr)
     debug("Output Mask: " + mask)
 
-    keepcharacters = (' ','.','_','+','-','(',')',',','#','\'')
+    keepcharacters = (' ','.','_','+','-','(',')',',','#','\'','[',']')
     mask = "".join(c for c in mask if c.isalnum() or c in keepcharacters).rstrip()
 
     files = glob.glob(dir + '/' + mask)


### PR DESCRIPTION
Fixes #39 by removing (not replacing) all non-alphanumeric characters that are also not `'()._,-+#][ ` (includes space)

Notably, despite systems with `*` and `/` in their name, this removes them.

Example actual ED system names with 'weird' characters:

```
1 G. Aquarii
NGC 2371/2 Sector YJ-A d0 <- EDMC-Screenshot would fail on this and 8 other systems with / in their name
GEN# +2.12450534
WDS J05353-0522Ja,Jb
Yin T'ien
Cl* NGC 1981 AR 131 <- Would fail on 10 systems with * in their name
Pipe (stem) Sector ZZ-Y c9
```

Not tested as I can't test on Linux (plugin doesn't load at all). Please review! (when I am able to test on Windows, I will, but that might not be for a bit)